### PR TITLE
Fix Fly.io deployment issues: proper secret handling and database migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,14 @@ COPY . .
 # Uncomment the following line in case you want to disable telemetry during the build.
 ENV NEXT_TELEMETRY_DISABLED 1
 
-# Build secrets are automatically available as environment variables
-
-RUN npm run build
+# Build with secrets from Fly.io
+RUN --mount=type=secret,id=NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY \
+    --mount=type=secret,id=CLERK_SECRET_KEY \
+    --mount=type=secret,id=MONGODB_URI \
+    export NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=$(cat /run/secrets/NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY) && \
+    export CLERK_SECRET_KEY=$(cat /run/secrets/CLERK_SECRET_KEY) && \
+    export MONGODB_URI=$(cat /run/secrets/MONGODB_URI) && \
+    npm run build
 
 # Install production dependencies only for runtime
 FROM base AS prod-deps

--- a/fly.toml
+++ b/fly.toml
@@ -5,7 +5,7 @@ app = 'dnd-tracker'
 primary_region = 'sea'
 
 [build]
-  secret = ["NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY", "MONGODB_URI", "CLERK_SECRET_KEY"]
+  # Build secrets must be passed via --build-secret flags in deploy command
 
 [env]
   NODE_ENV = 'production'

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react": "19.1.1",
     "react-dom": "19.1.1",
     "react-hook-form": "^7.62.0",
+    "migrate-mongoose": "^4.0.0",
     "svix": "^1.74.1",
     "tailwind-merge": "^3.3.1",
     "zod": "^4.1.1"
@@ -66,7 +67,6 @@
     "jest": "^30.0.5",
     "jest-environment-jsdom": "^30.0.5",
     "markdownlint-cli": "^0.45.0",
-    "migrate-mongoose": "^4.0.0",
     "mongodb-memory-server": "^10.2.0",
     "msw": "^2.10.5",
     "postcss": "^8.5.6",


### PR DESCRIPTION
## Summary

Fixes critical deployment failures by implementing proper build-time secret injection and database migration support.

## Changes Made

### 1. Docker Secret Handling
- **Problem**: Build secrets weren't available during Docker build, causing Next.js prerendering to fail with "Missing NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY environment variable"
- **Solution**: Implemented Docker BuildKit secret mounts with `--mount=type=secret` syntax
- **Files**: `Dockerfile`

### 2. Fly.io Configuration  
- **Problem**: `[build] secret = [...]` syntax in fly.toml doesn't work with Docker BuildKit
- **Solution**: Removed broken config, secrets now passed via `--build-secret` deploy flags
- **Files**: `fly.toml`

### 3. Database Migrations
- **Problem**: `migrate-mongoose` in devDependencies caused "sh: migrate-mongoose: not found" during production deployment
- **Solution**: Moved `migrate-mongoose` from devDependencies to production dependencies
- **Files**: `package.json`

## Deployment Command
To deploy with proper secrets:

```bash
flyctl deploy --build-secret NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="$CLERK_PK" \
               --build-secret CLERK_SECRET_KEY="$CLERK_SK" \
               --build-secret MONGODB_URI="$MONGODB_URI"
```

## Testing
- [x] Dockerfile builds successfully with secrets
- [x] Migration command available in production
- [x] No hardcoded secrets in Docker image
- [x] Lint checks pass

CLOSES: Resolves deployment failures