### PR TITLE
chore: update the fly.io region we use

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -2,7 +2,7 @@
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 
 app = 'dnd-tracker'
-primary_region = 'sea'
+primary_region = 'sjc'
 
 [build]
   [build.args]
@@ -29,3 +29,4 @@ cpus = 1
 
 [deploy]
 release_command = 'echo "Deploy starting..."'
+


### PR DESCRIPTION
This pull request makes a minor configuration update to the deployment settings for the `dnd-tracker` app. The most significant change is updating the primary region for deployment.

Deployment configuration:

* Changed the `primary_region` in `fly.toml` from `'sea'` (Seattle) to `'sjc'` (San Jose), which will affect where the app is primarily hosted.

Other:

* Added a blank line at the end of the `[deploy]` section in `fly.toml` for formatting consistency.