### PR TITLE
Issue: #159 Fix Clerk 500 error on Fly.io deployment

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -5,6 +5,11 @@ app = 'dnd-tracker'
 primary_region = 'sjc'
 
 [build]
+# Pass secrets as build arguments for Next.js NEXT_PUBLIC_ variables
+# These reference the Fly.io secrets and make them available during Docker build
+[build.args]
+  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "{{ .Env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}"
+  NEXT_PUBLIC_APP_URL = "{{ .Env.NEXT_PUBLIC_APP_URL }}"
 
 [env]
 NODE_ENV = 'production'


### PR DESCRIPTION
CLOSES: #159

## Summary

- Fixed 500 error when accessing https://dnd-tracker.fly.dev/
- Root cause: Next.js `NEXT_PUBLIC_` variables are embedded at build time, but Fly.io secrets are runtime-only
- Solution: Configure fly.toml to pass secrets as Docker build arguments using `{{ .Env.VAR_NAME }}` syntax

## Changes

### fly.toml
- Added `[build.args]` section
- Reference `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` and `NEXT_PUBLIC_APP_URL` secrets as build arguments
- Centralized configuration for easy environment migration

## Technical Details

The Dockerfile already accepts these variables as `ARG`, but Fly.io wasn't passing them during build. The `{{ .Env.SECRET_NAME }}` syntax in fly.toml instructs Fly.io to inject secret values as build arguments.

This keeps configuration in a single location (fly.toml) - when migrating environments, only the Fly.io secrets need to be updated.

## Test Plan

- ✅ All tests pass locally (npm run test:ci)
- ✅ Build succeeds (npm run build)
- ✅ ESLint and Markdown linting pass
- 🔄 Remote Codacy scan will verify on PR
- 🔄 Deployment to Fly.io will validate the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)