### PR TITLE
Issue: #161 Add home page navigation with login and profile links

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,46 +1,41 @@
-import { ClerkProvider } from '@clerk/nextjs'
-import clerkConfig from '@/lib/auth/clerk-config'
-
 export default function AuthLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
   return (
-    <ClerkProvider publishableKey={clerkConfig.publishableKey}>
-      <div className="min-h-screen bg-gradient-to-br from-lair-dungeon via-gray-900 to-dragon-black">
-        {/* Background pattern for D&D theme */}
-        <div className="absolute inset-0 bg-[url('/grid.svg')] bg-center [mask-image:linear-gradient(180deg,white,rgba(255,255,255,0))]" />
+    <div className="min-h-screen bg-gradient-to-br from-lair-dungeon via-gray-900 to-dragon-black">
+      {/* Background pattern for D&D theme */}
+      <div className="absolute inset-0 bg-[url('/grid.svg')] bg-center [mask-image:linear-gradient(180deg,white,rgba(255,255,255,0))]" />
 
-        <div className="relative flex min-h-screen flex-col items-center justify-center px-4">
-          {/* Header with D&D branding */}
-          <div className="mb-8 text-center">
-            <h1 className="text-4xl font-bold text-white mb-2">
-              D&D Encounter Tracker
-            </h1>
-            <p className="text-dragon-gold text-lg">
-              Manage your adventures with legendary precision
-            </p>
-          </div>
+      <div className="relative flex min-h-screen flex-col items-center justify-center px-4">
+        {/* Header with D&D branding */}
+        <div className="mb-8 text-center">
+          <h1 className="text-4xl font-bold text-white mb-2">
+            D&D Encounter Tracker
+          </h1>
+          <p className="text-dragon-gold text-lg">
+            Manage your adventures with legendary precision
+          </p>
+        </div>
 
-          {/* Auth form container */}
-          <div className="w-full max-w-md">
-            <div className="rounded-lg border border-dragon-gold/20 bg-card/90 backdrop-blur-sm shadow-2xl">
-              <div className="p-8">
-                {children}
-              </div>
+        {/* Auth form container */}
+        <div className="w-full max-w-md">
+          <div className="rounded-lg border border-dragon-gold/20 bg-card/90 backdrop-blur-sm shadow-2xl">
+            <div className="p-8">
+              {children}
             </div>
           </div>
+        </div>
 
-          {/* Footer */}
-          <div className="mt-8 text-center text-sm text-gray-400">
-            <p>
-              Ready to begin your quest?{' '}
-              <span className="text-dragon-gold">Adventure awaits!</span>
-            </p>
-          </div>
+        {/* Footer */}
+        <div className="mt-8 text-center text-sm text-gray-400">
+          <p>
+            Ready to begin your quest?{' '}
+            <span className="text-dragon-gold">Adventure awaits!</span>
+          </p>
         </div>
       </div>
-    </ClerkProvider>
+    </div>
   )
 }

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,7 +1,6 @@
-import { ClerkProvider, UserButton } from '@clerk/nextjs'
+import { UserButton } from '@clerk/nextjs'
 import Link from 'next/link'
 import { Shield, Swords, Users, BookOpen, Settings, Home } from 'lucide-react'
-import clerkConfig from '@/lib/auth/clerk-config'
 import { Button } from '@/components/ui/button'
 
 export default function DashboardLayout({
@@ -10,8 +9,7 @@ export default function DashboardLayout({
   children: React.ReactNode
 }) {
   return (
-    <ClerkProvider publishableKey={clerkConfig.publishableKey}>
-      <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-background">
         {/* Navigation Header */}
         <header className="border-b border-border bg-card/50 backdrop-blur-sm sticky top-0 z-50">
           <div className="container mx-auto px-4">
@@ -157,6 +155,5 @@ export default function DashboardLayout({
           </div>
         </footer>
       </div>
-    </ClerkProvider>
   )
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next'
+import { ClerkProvider } from '@clerk/nextjs'
+import clerkConfig from '@/lib/auth/clerk-config'
 import './globals.css'
 
 export const metadata: Metadata = {
@@ -12,8 +14,10 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en">
-      <body>{children}</body>
-    </html>
+    <ClerkProvider publishableKey={clerkConfig.publishableKey}>
+      <html lang="en">
+        <body>{children}</body>
+      </html>
+    </ClerkProvider>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,10 +2,12 @@ import Link from 'next/link'
 import { Shield, Swords, Users, Clock, Star, Check } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { SiteHeader } from '@/components/layout/site-header'
 
 export default function HomePage() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-background via-card to-background">
+      <SiteHeader />
       {/* Hero Section */}
       <section className="relative py-20 px-4">
         <div className="absolute inset-0 bg-[url('/grid.svg')] bg-center [mask-image:linear-gradient(180deg,white,rgba(255,255,255,0))]" />

--- a/src/components/layout/site-header.tsx
+++ b/src/components/layout/site-header.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import Link from 'next/link'
+import { Shield } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useAuth } from '@clerk/nextjs'
+
+export function SiteHeader() {
+  const { isSignedIn } = useAuth()
+
+  return (
+    <header className="border-b border-border bg-card/50 backdrop-blur-sm sticky top-0 z-50">
+      <div className="container mx-auto px-4">
+        <div className="flex h-16 items-center justify-between">
+          {/* Logo and Title */}
+          <Link href="/" className="flex items-center space-x-2">
+            <Shield className="h-8 w-8 text-dragon-red" />
+            <div>
+              <h1 className="text-xl font-bold text-foreground">
+                D&D Tracker
+              </h1>
+              <p className="text-xs text-muted-foreground">
+                Encounter Manager
+              </p>
+            </div>
+          </Link>
+
+          {/* Navigation Links */}
+          <div className="flex items-center space-x-4">
+            {isSignedIn ? (
+              <>
+                <Button variant="ghost" size="sm" asChild>
+                  <Link href="/dashboard">
+                    Dashboard
+                  </Link>
+                </Button>
+                <Button variant="outline" size="sm" asChild>
+                  <Link href="/settings/profile">
+                    Profile
+                  </Link>
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button variant="ghost" size="sm" asChild>
+                  <Link href="/sign-in">
+                    Sign In
+                  </Link>
+                </Button>
+                <Button variant="dragon" size="sm" asChild>
+                  <Link href="/sign-up">
+                    Get Started
+                  </Link>
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/tests/unit/components/layout/site-header.test.tsx
+++ b/tests/unit/components/layout/site-header.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * Unit tests for SiteHeader component
+ * Tests the navigation header component structure and links
+ */
+
+import { describe, test, expect } from '@jest/globals'
+import { render, screen } from '@testing-library/react'
+
+// Mock Clerk's useAuth hook to return unauthenticated state
+jest.mock('@clerk/nextjs', () => ({
+  useAuth: jest.fn(() => ({ isSignedIn: false })),
+}))
+
+import { SiteHeader } from '@/components/layout/site-header'
+
+describe('SiteHeader', () => {
+  test('renders header with logo and title', () => {
+    render(<SiteHeader />)
+
+    expect(screen.getByText('D&D Tracker')).toBeInTheDocument()
+    expect(screen.getByText('Encounter Manager')).toBeInTheDocument()
+  })
+
+  test('logo links to home page', () => {
+    render(<SiteHeader />)
+
+    const logoLink = screen.getByText('D&D Tracker').closest('a')
+    expect(logoLink).toHaveAttribute('href', '/')
+  })
+
+  test('renders navigation buttons', () => {
+    render(<SiteHeader />)
+
+    // Component should render navigation buttons
+    // (either Sign In/Get Started or Dashboard/Profile depending on auth)
+    const links = screen.getAllByRole('link')
+    expect(links.length).toBeGreaterThan(0)
+  })
+
+  test('header is sticky and positioned at top', () => {
+    render(<SiteHeader />)
+
+    const header = screen.getByRole('banner')
+    expect(header).toHaveClass('sticky', 'top-0')
+  })
+})


### PR DESCRIPTION
CLOSES: #161

Added navigation header to home page with authentication-aware login and profile links.

Created reusable SiteHeader component that shows Sign In/Get Started for unauthenticated users and Dashboard/Profile for authenticated users.