### PR TITLE
Fix: Remove server-side redirects causing URL toggle loop

### DIFF
--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -1,15 +1,6 @@
 import { SignIn } from '@clerk/nextjs'
-import { auth } from '@clerk/nextjs/server'
-import { redirect } from 'next/navigation'
 
-export default async function SignInPage() {
-  const { userId } = await auth()
-
-  // Redirect signed-in users to dashboard
-  if (userId) {
-    redirect('/dashboard')
-  }
-
+export default function SignInPage() {
   return (
     <div className="flex items-center justify-center">
       <SignIn />

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -1,15 +1,6 @@
 import { SignUp } from '@clerk/nextjs'
-import { auth } from '@clerk/nextjs/server'
-import { redirect } from 'next/navigation'
 
-export default async function SignUpPage() {
-  const { userId } = await auth()
-
-  // Redirect signed-in users to dashboard
-  if (userId) {
-    redirect('/dashboard')
-  }
-
+export default function SignUpPage() {
   return (
     <div className="flex items-center justify-center">
       <SignUp />

--- a/tests/unit/app/auth/sign-up.test.tsx
+++ b/tests/unit/app/auth/sign-up.test.tsx
@@ -2,46 +2,34 @@
  * Unit tests for SignUp page
  */
 
-import { describe, test, expect, jest, beforeEach } from '@jest/globals'
-
-// Mock next/navigation redirect
-const mockRedirect = jest.fn()
-jest.mock('next/navigation', () => ({
-  redirect: mockRedirect,
-}))
-
-// Mock Clerk auth
-const mockAuth = jest.fn()
-jest.mock('@clerk/nextjs/server', () => ({
-  auth: mockAuth,
-}))
+import { describe, test, expect, jest } from '@jest/globals'
+import { render, screen } from '@testing-library/react'
 
 // Mock Clerk's SignUp component
 jest.mock('@clerk/nextjs', () => ({
   SignUp: jest.fn(() => <div data-testid="clerk-sign-up">Clerk SignUp Component</div>),
 }))
 
+// Dynamically import page after mocks are set up
+const getSignUpPage = async () => {
+  const module = await import('@/app/(auth)/sign-up/page')
+  return module.default
+}
+
 describe('SignUpPage', () => {
-  beforeEach(() => {
-    jest.clearAllMocks()
+  test('renders the Clerk SignUp component', async () => {
+    const SignUpPage = await getSignUpPage()
+    render(<SignUpPage />)
+
+    expect(screen.getByTestId('clerk-sign-up')).toBeInTheDocument()
+    expect(screen.getByText('Clerk SignUp Component')).toBeInTheDocument()
   })
 
-  test('redirects signed-in users to dashboard', async () => {
-    mockAuth.mockResolvedValue({ userId: 'user_123' })
+  test('wraps SignUp in centered container', async () => {
+    const SignUpPage = await getSignUpPage()
+    const { container } = render(<SignUpPage />)
 
-    const SignUpPage = (await import('@/app/(auth)/sign-up/page')).default
-    await SignUpPage()
-
-    expect(mockRedirect).toHaveBeenCalledWith('/dashboard')
-  })
-
-  test('allows unauthenticated users to see sign-up page', async () => {
-    mockAuth.mockResolvedValue({ userId: null })
-
-    const SignUpPage = (await import('@/app/(auth)/sign-up/page')).default
-    const result = await SignUpPage()
-
-    expect(mockRedirect).not.toHaveBeenCalled()
-    expect(result).toBeDefined()
+    const wrapper = container.querySelector('.flex.items-center.justify-center')
+    expect(wrapper).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Problem

After merging PR #166, users experienced a URL toggling/redirect loop issue where the page would rapidly switch between `/sign-in` and `/profile-setup`, preventing proper page load.

## Root Cause

The server-side `auth()` checks added to sign-in/sign-up pages in PR #166 were conflicting with Clerk's internal redirect handling:

1. Sign-in page checks `userId` and redirects signed-in users to `/dashboard`
2. Middleware redirects users without completed profiles to `/profile-setup`
3. This creates a conflict with Clerk's own redirect logic configured via `afterSignInUrl` and `afterSignUpUrl`

## Solution

Remove the server-side auth checks from sign-in and sign-up pages. Let Clerk components handle redirects internally using the configuration we already have in `clerk-config.ts`:

```typescript
afterSignInUrl: '/dashboard',
afterSignUpUrl: '/profile-setup',
```

Clerk's `<SignIn />` and `<SignUp />` components handle signed-in user redirects automatically and correctly without causing conflicts with our middleware.

## Changes

- Reverted `src/app/(auth)/sign-in/page.tsx` to simple Clerk component rendering
- Reverted `src/app/(auth)/sign-up/page.tsx` to simple Clerk component rendering  
- Updated tests to match original component behavior
- All 292 tests pass

## Testing

- ✅ All unit tests pass
- ✅ No ESLint errors
- ✅ Middleware profile setup flow remains intact
- ✅ Clerk handles authenticated user redirects automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)